### PR TITLE
Worker configuration is no longer needed for browser builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ export default nextConfig;
 Custom builds, Electron/NW.js, or specific deployment environments—you may need to manually configure the worker source.
 
 ```js
-import {getWorkerPath, getWorkerSource} from "pdf-parse/worker"; // Import this before importing "pdf-parse"
+// Import this before importing "pdf-parse"
+import {getWorkerPath, getWorkerSource} from "pdf-parse/worker"; 
 import {PDFParse} from "pdf-parse";
 
 // CommonJS
@@ -306,7 +307,10 @@ try {
 ```html
 <!-- ES Module -->
 <script type="module">
-  import { PDFParse } from 'https://cdn.jsdelivr.net/npm/pdf-parse@latest/dist/browser/pdf-parse.es.min.js';
+  import {PDFParse} from 'https://cdn.jsdelivr.net/npm/pdf-parse@latest/+esm';
+  const parser = new PDFParse({url:'https://mehmet-kozan.github.io/pdf-parse/pdf/bitcoin.pdf'});
+  const result = await parser.getText()
+  console.log(result.text)
 </script>
 ```
 
@@ -325,21 +329,7 @@ try {
 
 
 
-### Worker Configuration
 
-In browser environments, `pdf-parse` requires a separate worker file to process PDFs in a background thread. By default, `pdf-parse` automatically loads the worker from the jsDelivr CDN. However, you can configure a custom worker source if needed.
-
-**When to Configure Worker Source:**
-- Using a custom build of `pdf-parse`
-- Self-hosting worker files for security or offline requirements
-- Using a different CDN provider
-
-**Available Worker Files:**
-
-- `https://cdn.jsdelivr.net/npm/pdf-parse@latest/dist/browser/pdf.worker.mjs`
-- `https://cdn.jsdelivr.net/npm/pdf-parse@latest/dist/browser/pdf.worker.min.mjs`
-
-See [`example/basic.esm.worker.html`](example/basic.esm.worker.html) for a working example of browser usage with worker configuration.
 
 ## Similar Packages
 * [pdf2json](https://www.npmjs.com/package/pdf2json) — Buggy, memory leaks, uncatchable errors in some PDF files.
@@ -365,7 +355,8 @@ Requires additional setup — import and configure a compatible CanvasFactory or
 
 ESM 
 ```js
-import { CustomCanvasFactory } from 'pdf-parse/canvas'; // Import this before importing "pdf-parse"
+// Import this before importing "pdf-parse"
+import { CustomCanvasFactory } from 'pdf-parse/canvas'; 
 import { PDFParse } from 'pdf-parse';
 
 const parser = new PDFParse({ data: buffer, CanvasFactory: CustomCanvasFactory });
@@ -374,7 +365,8 @@ const parser = new PDFParse({ data: buffer, CanvasFactory: CustomCanvasFactory }
 
 CommonJS
 ```js
-const { CustomCanvasFactory } = require('pdf-parse/canvas'); // Import this before importing "pdf-parse"
+// Import this before importing "pdf-parse"
+const { CustomCanvasFactory } = require('pdf-parse/canvas'); 
 const { PDFParse } = require('pdf-parse');
 
 const parser = new PDFParse({ data: buffer, CanvasFactory: CustomCanvasFactory });

--- a/README.worker.md
+++ b/README.worker.md
@@ -56,4 +56,22 @@ PDFParse.setWorker(workerUrl);
 - Electron/NW.js packaging with non-standard import paths
 - Self-hosting worker files for offline or security requirements
 
-If you don't need to set a custom worker, you can ignore this file — `pdf-parse` will pick a sensible default.
+
+
+
+
+### Browser Worker Configuration
+
+In browser environments, `pdf-parse` requires a separate worker file to process PDFs in a background thread. By default, `pdf-parse` automatically loads the worker from the jsDelivr CDN. However, you can configure a custom worker source if needed.
+
+**When to Configure Worker Source:**
+- Using a custom build of `pdf-parse`
+- Self-hosting worker files for security or offline requirements
+- Using a different CDN provider
+
+**Available Worker Files:**
+
+- `https://cdn.jsdelivr.net/npm/pdf-parse@latest/dist/browser/pdf.worker.mjs`
+- `https://cdn.jsdelivr.net/npm/pdf-parse@latest/dist/browser/pdf.worker.min.mjs`
+
+See [`example/basic.esm.worker.html`](example/basic.esm.worker.html) for a working example of browser usage with worker configuration.

--- a/bin/worker/index.ts
+++ b/bin/worker/index.ts
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import * as WorkerUrl from 'pdfjs-dist/legacy/build/pdf.worker.mjs?url';
+import * as WorkerUrl from 'pdfjs-dist/legacy/build/pdf.worker.min.mjs?url';
 
 export function getWorkerSource() {
 	return WorkerUrl.default;

--- a/src/PDFParse.ts
+++ b/src/PDFParse.ts
@@ -74,11 +74,11 @@ export class PDFParse {
 			return pdfjs.GlobalWorkerOptions.workerSrc;
 		}
 
-		if (!PDFParse.isNodeJS) {
-			pdfjs.GlobalWorkerOptions.workerSrc =
-				'https://cdn.jsdelivr.net/npm/pdf-parse@latest/dist/browser/pdf.worker.min.mjs';
-			return pdfjs.GlobalWorkerOptions.workerSrc;
-		}
+		// if (!PDFParse.isNodeJS) {
+		// 	pdfjs.GlobalWorkerOptions.workerSrc =
+		// 		'https://cdn.jsdelivr.net/npm/pdf-parse@latest/dist/browser/pdf.worker.min.mjs';
+		// 	return pdfjs.GlobalWorkerOptions.workerSrc;
+		// }
 
 		return pdfjs.GlobalWorkerOptions.workerSrc;
 	}
@@ -978,4 +978,4 @@ export class PDFParse {
 	}
 }
 
-PDFParse.setWorker();
+//PDFParse.setWorker();

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,0 +1,37 @@
+/// <reference types="vite/client" />
+import * as WorkerUrl from 'pdfjs-dist/legacy/build/pdf.worker.min.mjs?url';
+
+import { PDFParse } from './PDFParse.js';
+
+PDFParse.setWorker(WorkerUrl.default);
+
+export { VerbosityLevel } from 'pdfjs-dist/legacy/build/pdf.mjs';
+export type {
+	DocumentInitParameters,
+	PDFDataRangeTransport,
+	PDFWorker,
+	TypedArray,
+} from 'pdfjs-dist/types/src/display/api.js';
+
+export { getHeader, type HeaderResult } from './HeaderResult.js';
+export type { EmbeddedImage, ImageKindKey, ImageKindValue, ImageResult, PageImages } from './ImageResult.js';
+export type { DateNode, InfoResult, Metadata, OutlineNode, PageLinkResult } from './InfoResult.js';
+export type { ParseParameters } from './ParseParameters.js';
+export type { Screenshot, ScreenshotResult } from './ScreenshotResult.js';
+export type { PageTableResult, TableResult } from './TableResult.js';
+export type { PageTextResult, TextResult } from './TextResult.js';
+
+/**
+ * The URL of the PDF.
+ * -
+ * Binary PDF data.
+ * Use TypedArrays (Uint8Array) to improve the memory usage. If PDF data is
+ * BASE64-encoded, use `atob()` to convert it to a binary string first.
+ * https://mozilla.github.io/pdf.js/examples/
+ *
+ * NOTE: If TypedArrays are used they will generally be transferred to the
+ * worker-thread. This will help reduce main-thread memory usage, however
+ * it will take ownership of the TypedArrays.
+ */
+
+export { PDFParse };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
 		"verbatimModuleSyntax": true
 	},
 	"include": ["src/**/*"],
-	"exclude": ["src/**/_*", "src/_**/*"]
+	"exclude": ["src/**/_*", "src/_**/*", "src/index.browser.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,5 +19,5 @@
 		"verbatimModuleSyntax": false
 	},
 	"include": ["src/**/*"],
-	"exclude": ["src/**/_*", "src/_**/*"]
+	"exclude": ["src/**/_*", "src/_**/*", "src/index.browser.ts"]
 }

--- a/vite.config.browser.min.ts
+++ b/vite.config.browser.min.ts
@@ -7,9 +7,9 @@ export default defineConfig({
 		outDir: 'dist/browser',
 		emptyOutDir: false,
 		sourcemap: false,
-		minify: true,
+		minify: 'terser',
 		lib: {
-			entry: 'src/index.ts',
+			entry: 'src/index.browser.ts',
 			name: 'PdfParse',
 			fileName: (format) => `pdf-parse.${format}.min.js`,
 			formats: ['es', 'umd'],

--- a/vite.config.browser.ts
+++ b/vite.config.browser.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 		sourcemap: true,
 		minify: false,
 		lib: {
-			entry: 'src/index.ts',
+			entry: 'src/index.browser.ts',
 			name: 'PdfParse',
 			fileName: (format) => `pdf-parse.${format}.js`,
 			formats: ['es', 'umd'],


### PR DESCRIPTION
Introduces src/index.browser.ts as a browser-specific entry point, sets up the correct PDF.js worker for browser builds, and updates Vite configs to use this entry. Documentation is improved for browser usage and worker configuration, and TypeScript configs now exclude the new browser entry from Node/TS builds. Also switches to the minified PDF.js worker in the worker index.