### PR TITLE
NPM publish workflow now triggers only on published releases.

### DIFF
--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -3,9 +3,6 @@ name: Publish NPM Package
 concurrency: publish
 
 on:
-  push:
-    tags:
-      - "v*.*.*" # Trigger only on version tags
   release:
     types: [published] # Trigger when a release is published
 
@@ -14,40 +11,8 @@ permissions:
   contents: read # Ensures the workflow can read repository contents
 
 jobs:
-  integration_test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22, 23, 24]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
-          show-progress: false
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
-
-      - name: Clean NPM Cache
-        run: npm cache clean --force
-
-      - name: Install
-        run: npm i
-
-      - name: Unit tests
-        run: npm test
-
-      - name: Integration tests
-        run: npm run test:i
-
   publish:
     runs-on: ubuntu-latest
-    needs: integration_test
     environment: publish
     steps:
       - name: Checkout
@@ -61,8 +26,6 @@ jobs:
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
             TAG_VERSION=$(node -p "require(process.env.GITHUB_EVENT_PATH).release.tag_name")
-          else
-            TAG_VERSION=${GITHUB_REF#refs/tags/}
           fi
           TAG_VERSION=${TAG_VERSION#v}
           echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
@@ -99,6 +62,15 @@ jobs:
       - name: Unit Tests
         run: npm test
 
-      - run: npm publish --provenance
+      - name: Set publish tag
+        id: publish_tag
+        run: |
+          if [[ "${{ steps.tag_version.outputs.version }}" == *"beta"* ]]; then
+            echo "tag=beta" >> $GITHUB_ENV
+          else
+            echo "tag=latest" >> $GITHUB_ENV
+          fi
+
+      - run: npm publish --provenance --access public --tag ${{ steps.publish_tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -66,9 +66,9 @@ jobs:
         id: publish_tag
         run: |
           if [[ "${{ steps.tag_version.outputs.version }}" == *"beta"* ]]; then
-            echo "tag=beta" >> $GITHUB_ENV
+            echo "tag=beta" >> $GITHUB_OUTPUT
           else
-            echo "tag=latest" >> $GITHUB_ENV
+            echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
       - run: npm publish --provenance --access public --tag ${{ steps.publish_tag.outputs.tag }}

--- a/docs/README.cli.md
+++ b/docs/README.cli.md
@@ -88,7 +88,7 @@ pdf-parse table document.pdf --format json
 - `-s, --scale <factor>`: Scale factor for screenshots (default: 1.0)
 - `-w, --width <px>`: Desired width for screenshots in pixels
 - `-l, --large`: Enable optimizations for large PDF files
-- `--magic`: Validate PDF magic bytes (default: true)
+- `--magic`: Validate PDF magic bytes
 - `-h, --help`: Show help message
 - `-v, --version`: Show version number
 


### PR DESCRIPTION
This pull request updates the workflow for publishing the NPM package and makes a minor documentation change. The main focus is on simplifying and improving the GitHub Actions workflow to ensure publishing only happens when a release is published, and to streamline the testing and publishing steps.

**Workflow improvements:**

* The NPM publish workflow now triggers only on published releases, not on version tags, making the release process more intentional and reliable.
* The integration test job for multiple Node.js versions was removed, simplifying the workflow and reducing CI run time. Now, only unit tests are run before publishing.
* The logic for extracting the version tag was simplified to only handle release events, removing fallback handling for tag pushes.
* The publish step now sets the NPM tag to `beta` if the version contains "beta", otherwise uses `latest`, ensuring correct tagging for pre-releases and stable versions. The publish command also explicitly sets public access.

**Documentation update:**

* The CLI documentation for the `--magic` option was updated to remove the default value, clarifying its usage.