### PR TITLE
Refactor test packaging and add unsupported tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ web_modules/
 .node_repl_history
 
 # Output of 'npm pack'
-*.tgz
+/*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/examples/get-image.mjs
+++ b/examples/get-image.mjs
@@ -9,4 +9,4 @@ const parser = new PDFParse({ url: link });
 const result = await parser.getImage();
 await parser.destroy();
 
-await writeFile('adobe.png', result.pages[0].images[0].data);
+await writeFile('./temp/adobe.png', result.pages[0].images[0].data);

--- a/examples/get-screenshot.mjs
+++ b/examples/get-screenshot.mjs
@@ -12,4 +12,4 @@ const parser = new PDFParse({ url: link });
 const result = await parser.getScreenshot({ scale: 1.5 });
 
 await parser.destroy();
-await writeFile('bitcoin.png', result.pages[0].data);
+await writeFile('./temp/bitcoin.png', result.pages[0].data);

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"test": "vitest run --reporter=default",
 		"test:p": "vitest run --config vitest.config.package.ts",
 		"test:i": "node scripts/integration.test.mjs",
-		"test:u": "node --test-reporter=dot --test tests/unsupported/*.test.cjs && node --test-reporter=dot --test tests/unsupported/*.test.mjs",
+		"test:u": "node scripts/unsupported.test.mjs",
 		"test:e": "node scripts/example.test.mjs",
 		"test:cli": "node --test-reporter=dot --test bin/*.test.mjs",
 		"test:all": "npm run build && npm run test && npm run test:p && npm run test:i && npm run test:u && npm run test:e && npm run test:cli",
@@ -128,7 +128,7 @@
 		"pack": "npm update --save && npm outdated && npm pack --dry-run"
 	},
 	"dependencies": {
-		"@napi-rs/canvas": "0.1.80",
+		"@napi-rs/canvas": "0.1.81",
 		"pdfjs-dist": "5.4.394"
 	},
 	"devDependencies": {

--- a/scripts/unsupported.test.mjs
+++ b/scripts/unsupported.test.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/** biome-ignore-all lint/suspicious/noConsole: <test script> */
+import { exec } from 'node:child_process';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const testDir = path.resolve(__dirname, '../tests/unsupported');
+
+
+
+function runCommand(cmd, cwd) {
+	return new Promise((resolve, reject) => {
+		exec(cmd, { cwd }, (error, stdout, stderr) => {
+			if (error) {
+				console.error(`Error running ${cmd} in ${cwd}:`, stderr);
+				reject(error);
+			} else {
+				//console.log(`Output of ${cmd} in ${cwd}:`, stdout);
+				resolve(stdout);
+			}
+		});
+	});
+}
+
+
+
+async function main() {
+
+	console.log(`Processing: ${testDir}`);
+	try {
+		await runCommand('npm install', testDir);
+		await runCommand('npm test', testDir);
+	} catch (err) {
+		console.error(`Failed in ${testDir}:`, err);
+		throw err;
+	}
+    
+}
+
+main()
+	.then(() => {
+		console.log('\nUnsupported Tests Succeeded!..\n');
+		process.exit(0);
+	})
+	.catch((err) => {
+		console.error('\nUnsupported Tests Failed!..\n', err);
+		process.exit(1);
+	});

--- a/tests/integration/test_ava_suite_cjs/package.json
+++ b/tests/integration/test_ava_suite_cjs/package.json
@@ -12,7 +12,7 @@
 		"test": "ava common.test.cjs --verbose --no-cache --serial --no-worker-threads"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	},
 	"devDependencies": {
 		"ava": "latest"

--- a/tests/integration/test_cjs/package.json
+++ b/tests/integration/test_cjs/package.json
@@ -11,6 +11,6 @@
 		"test": "node index.js"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	}
 }

--- a/tests/integration/test_esm/package.json
+++ b/tests/integration/test_esm/package.json
@@ -12,6 +12,6 @@
 		"test": "node ./index.mjs"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	}
 }

--- a/tests/integration/test_ts_common/package.json
+++ b/tests/integration/test_ts_common/package.json
@@ -11,7 +11,7 @@
 		"build": "tsc"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	},
 	"devDependencies": {
 		"ts-node": "^10.9.2",

--- a/tests/integration/test_ts_issue_14/package.json
+++ b/tests/integration/test_ts_issue_14/package.json
@@ -11,7 +11,7 @@
 		"build": "tsc"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	},
 	"devDependencies": {
 		"@types/node-fetch": "^2.6.13",

--- a/tests/unsupported/.npmrc
+++ b/tests/unsupported/.npmrc
@@ -1,0 +1,6 @@
+package-lock=false
+audit=false
+fund=false
+loglevel=error
+prefer-offline=true
+save=true

--- a/tests/unsupported/package.json
+++ b/tests/unsupported/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "unsupported_test",
+	"version": "1.0.0",
+	"description": "",
+	"license": "ISC",
+	"author": "",
+	"type": "commonjs",
+	"main": "common.test.cjs",
+	"private": "true",
+	"scripts": {
+        "test": "node --test-reporter=dot --test *.test.cjs && node --test-reporter=dot --test *.test.mjs"
+
+	},
+	"dependencies": {
+		"pdf-parse": "file:../../reports/pdf-parse.tgz"
+	}
+}


### PR DESCRIPTION
Moved packed pdf-parse.tgz to reports directory and updated integration test package.json files to reference the new location. Added scripts/unsupported.test.mjs and tests/unsupported for running unsupported environment tests. Updated .gitignore to only ignore tgz files in the root. Improved integration test script to only pack on Node.js >= 22.20.0. Bumped @napi-rs/canvas dependency to 0.1.81.