### PR TITLE
Refactor test packaging and add unsupported tests

### DIFF
--- a/.github/workflows/test_unsupported.yml
+++ b/.github/workflows/test_unsupported.yml
@@ -33,8 +33,5 @@ jobs:
       - name: Clean NPM Cache
         run: npm cache clean --force
 
-      - name: Install
-        run: npm i
-
       - name: Unsupported tests
         run: npm run test:u

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ web_modules/
 .node_repl_history
 
 # Output of 'npm pack'
-*.tgz
+/*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/examples/get-image.mjs
+++ b/examples/get-image.mjs
@@ -9,4 +9,4 @@ const parser = new PDFParse({ url: link });
 const result = await parser.getImage();
 await parser.destroy();
 
-await writeFile('adobe.png', result.pages[0].images[0].data);
+await writeFile('./temp/adobe.png', result.pages[0].images[0].data);

--- a/examples/get-screenshot.mjs
+++ b/examples/get-screenshot.mjs
@@ -12,4 +12,4 @@ const parser = new PDFParse({ url: link });
 const result = await parser.getScreenshot({ scale: 1.5 });
 
 await parser.destroy();
-await writeFile('bitcoin.png', result.pages[0].data);
+await writeFile('./temp/bitcoin.png', result.pages[0].data);

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"test": "vitest run --reporter=default",
 		"test:p": "vitest run --config vitest.config.package.ts",
 		"test:i": "node scripts/integration.test.mjs",
-		"test:u": "node --test-reporter=dot --test tests/unsupported/*.test.cjs && node --test-reporter=dot --test tests/unsupported/*.test.mjs",
+		"test:u": "node scripts/unsupported.test.mjs",
 		"test:e": "node scripts/example.test.mjs",
 		"test:cli": "node --test-reporter=dot --test bin/*.test.mjs",
 		"test:all": "npm run build && npm run test && npm run test:p && npm run test:i && npm run test:u && npm run test:e && npm run test:cli",
@@ -128,7 +128,7 @@
 		"pack": "npm update --save && npm outdated && npm pack --dry-run"
 	},
 	"dependencies": {
-		"@napi-rs/canvas": "0.1.80",
+		"@napi-rs/canvas": "0.1.81",
 		"pdfjs-dist": "5.4.394"
 	},
 	"devDependencies": {

--- a/scripts/unsupported.test.mjs
+++ b/scripts/unsupported.test.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/** biome-ignore-all lint/suspicious/noConsole: <test script> */
+import { exec } from 'node:child_process';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const testDir = path.resolve(__dirname, '../tests/unsupported');
+
+
+
+function runCommand(cmd, cwd) {
+	return new Promise((resolve, reject) => {
+		exec(cmd, { cwd }, (error, stdout, stderr) => {
+			if (error) {
+				console.error(`Error running ${cmd} in ${cwd}:`, stderr);
+				reject(error);
+			} else {
+				//console.log(`Output of ${cmd} in ${cwd}:`, stdout);
+				resolve(stdout);
+			}
+		});
+	});
+}
+
+
+
+async function main() {
+
+	console.log(`Processing: ${testDir}`);
+	try {
+		await runCommand('npm install', testDir);
+		await runCommand('npm test', testDir);
+	} catch (err) {
+		console.error(`Failed in ${testDir}:`, err);
+		throw err;
+	}
+    
+}
+
+main()
+	.then(() => {
+		console.log('\nUnsupported Tests Succeeded!..\n');
+		process.exit(0);
+	})
+	.catch((err) => {
+		console.error('\nUnsupported Tests Failed!..\n', err);
+		process.exit(1);
+	});

--- a/tests/integration/test_ava_suite_cjs/package.json
+++ b/tests/integration/test_ava_suite_cjs/package.json
@@ -12,7 +12,7 @@
 		"test": "ava common.test.cjs --verbose --no-cache --serial --no-worker-threads"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	},
 	"devDependencies": {
 		"ava": "latest"

--- a/tests/integration/test_cjs/package.json
+++ b/tests/integration/test_cjs/package.json
@@ -11,6 +11,6 @@
 		"test": "node index.js"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	}
 }

--- a/tests/integration/test_esm/package.json
+++ b/tests/integration/test_esm/package.json
@@ -12,6 +12,6 @@
 		"test": "node ./index.mjs"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	}
 }

--- a/tests/integration/test_ts_common/package.json
+++ b/tests/integration/test_ts_common/package.json
@@ -11,7 +11,7 @@
 		"build": "tsc"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	},
 	"devDependencies": {
 		"ts-node": "^10.9.2",

--- a/tests/integration/test_ts_issue_14/package.json
+++ b/tests/integration/test_ts_issue_14/package.json
@@ -11,7 +11,7 @@
 		"build": "tsc"
 	},
 	"dependencies": {
-		"pdf-parse": "file:../../../pdf-parse.tgz"
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
 	},
 	"devDependencies": {
 		"@types/node-fetch": "^2.6.13",

--- a/tests/unsupported/.npmrc
+++ b/tests/unsupported/.npmrc
@@ -1,0 +1,6 @@
+package-lock=false
+audit=false
+fund=false
+loglevel=error
+prefer-offline=true
+save=true

--- a/tests/unsupported/package.json
+++ b/tests/unsupported/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "unsupported_test",
+	"version": "1.0.0",
+	"description": "",
+	"license": "ISC",
+	"author": "",
+	"type": "commonjs",
+	"main": "common.test.cjs",
+	"private": "true",
+	"scripts": {
+        "test": "node --test-reporter=dot --test *.test.cjs && node --test-reporter=dot --test *.test.mjs"
+
+	},
+	"dependencies": {
+		"pdf-parse": "file:../../reports/pdf-parse.tgz"
+	}
+}


### PR DESCRIPTION
This pull request refactors how unsupported tests are run and managed, improves integration test artifact handling, and makes minor fixes to example scripts and dependencies. The most significant changes include moving unsupported test execution to a dedicated script and directory, adjusting integration test packaging, and updating dependency references for consistency and reliability.

**Testing and Test Infrastructure Improvements:**

* Replaces the previous `test:u` npm script with a new script (`scripts/unsupported.test.mjs`) that runs unsupported tests in a dedicated directory using a standalone Node.js process. Updates the workflow and `package.json` to use this new approach, improving isolation and maintainability. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L111-R111)`, `[[2]](diffhunk://#diff-33e5cad048e2e5856a7ae6070545216398259f400c01efd798e03560ab5f4649L36-L38)`, `[[3]](diffhunk://#diff-3fba02863bba8fda425f3d5c2b5f4adf4f1a8a82abbf0c98c9aabb46e99b47acR1-R51)`)
* Adds a new `tests/unsupported` directory with its own `package.json` and `.npmrc` for running unsupported tests, ensuring dependencies are correctly sourced from the built package tarball in `reports/`. (`[[1]](diffhunk://#diff-d83dea1633f388417ff78327d2c041078c4d18670a0b222a80a84086e0627dd1R1-R17)`, `[[2]](diffhunk://#diff-f51c032fd6258f2d596e9726e07fc5fd78aca0d7e4073fb0278571f0ccd5ac07R1-R6)`)

**Integration Test Packaging and Dependency Management:**

* Updates integration test projects to reference the built package tarball from `reports/pdf-parse.tgz` instead of the project root, ensuring consistency and avoiding stale artifacts. (`[[1]](diffhunk://#diff-1a9bd8e55ad5534142e014fddec856024046ea437c83b809f5b942227d24ddc4L15-R15)`, `[[2]](diffhunk://#diff-9bf50c037e9b52be3630c7a214cce1802c3a2539da39a1bb4b16358c43612635L14-R14)`, `[[3]](diffhunk://#diff-2c8c81aad18f9f17032c738221ccc6ce952caa4e2ed9c50c9309fe1370dacf20L15-R15)`, `[[4]](diffhunk://#diff-e46c1af7bb30c3e842d5f5a9f68788ea37b211bad20c6dc164200f70a593515dL14-R14)`, `[[5]](diffhunk://#diff-c9b8d2cf7ee598f1ddb03295c5a11e610ea608b50a3fbbdffaa1606b9908992cL14-R14)`)
* Modifies the integration test packaging process to output the tarball to the `temp` directory and copy it to `reports/`, with a Node.js version check to ensure compatibility. (`[scripts/integration.test.mjsL55-R75](diffhunk://#diff-7f809cf0b059377e1bda95bb7d411929e191fbce31e7f204ca8d34ebd7187794L55-R75)`)

**Dependency Updates:**

* Updates `@napi-rs/canvas` dependency from version `0.1.80` to `0.1.81` in `package.json`. (`[package.jsonL131-R131](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L131-R131)`)

**Example Script Fixes:**

* Changes output paths in example scripts to write generated images to the `./temp` directory, preventing clutter in the project root. (`[[1]](diffhunk://#diff-2864d28079e4c6462afe44d9766185010a95671807603e3cf3a7801847ef99b3L12-R12)`, `[[2]](diffhunk://#diff-3cb2a45ae1a9e203069e486cf623f4a2da3ccc7ad5f7af2ff18253173f560fc6L15-R15)`)