### PR TITLE
Jest integration test added.

### DIFF
--- a/tests/integration/test_jest_light_runner/.npmrc
+++ b/tests/integration/test_jest_light_runner/.npmrc
@@ -1,0 +1,6 @@
+package-lock=false
+audit=false
+fund=false
+loglevel=error
+prefer-offline=true
+save=true

--- a/tests/integration/test_jest_light_runner/.vscode/launch.json
+++ b/tests/integration/test_jest_light_runner/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest Debug",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+                "--runInBand",
+                "--no-cache",
+                "--verbose"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+            },
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "smartStep": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/**/*.js",
+                "${workspaceFolder}/node_modules/**/*.js",
+                "${workspaceFolder}/node_modules/**/*.mjs"
+            ],
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/**",
+                "!**/node_modules/**"
+            ],
+        }
+    ]
+}

--- a/tests/integration/test_jest_light_runner/common.test.cjs
+++ b/tests/integration/test_jest_light_runner/common.test.cjs
@@ -1,0 +1,42 @@
+
+const { PDFParse } = require('pdf-parse');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const __pdf = path.join(__dirname, '../../../reports/pdf/');
+
+
+test('jest framework test - dummy-test.pdf', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'dummy.pdf'));
+	const parser = new PDFParse({ data});
+	const result = await parser.getText();
+	await parser.destroy();
+	expect(result.text).toContain('Dummy PDF file');
+});
+
+test('jest framework test - image-test.pdf - ss', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'image-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getScreenshot();
+	await parser.destroy();
+	expect(result.pages[0].dataUrl.length).toBeGreaterThan(0);
+});
+
+test('jest framework test - image-test.pdf - embed', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'image-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getImage();
+	await parser.destroy();
+	expect(result.pages[0].images[0].dataUrl.length).toBeGreaterThan(0);
+});
+
+test('jest framework test - full-test.pdf', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'default-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getText({ last: 1 });
+	await parser.destroy();
+	expect(result.text).toContain('be interpreted as necessarily');
+});

--- a/tests/integration/test_jest_light_runner/jest.config.cjs
+++ b/tests/integration/test_jest_light_runner/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.cjs'],
+  runner: 'jest-light-runner',
+};

--- a/tests/integration/test_jest_light_runner/nodejs.test.cjs
+++ b/tests/integration/test_jest_light_runner/nodejs.test.cjs
@@ -1,0 +1,8 @@
+
+
+test('isNodeJS', () => {
+
+    const isNodeJS = typeof process === "object" && process + "" === "[object process]" && !process.versions.nw && !(process.versions.electron && process.type && process.type !== "browser");
+    expect(isNodeJS).toBe(true);
+
+});

--- a/tests/integration/test_jest_light_runner/package.json
+++ b/tests/integration/test_jest_light_runner/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "test_jest_light_runner",
+	"version": "1.0.0",
+	"description": "",
+	"license": "ISC",
+	"author": "",
+	"type": "commonjs",
+	"main": "common.test.cjs",
+	"private": "true",
+	"scripts": {
+		"build": "",
+		"test": "jest --verbose --no-cache --runInBand"
+	},
+	"dependencies": {
+		
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
+	},
+	"devDependencies": {
+		"cross-env": "^10.1.0",
+		"jest": "latest",
+		"jest-light-runner": "^0.7.10"
+	}
+}

--- a/tests/integration/test_jest_suite_cjs_vm/.npmrc
+++ b/tests/integration/test_jest_suite_cjs_vm/.npmrc
@@ -1,0 +1,7 @@
+package-lock=false
+audit=false
+fund=false
+loglevel=error
+prefer-offline=true
+save=true
+legacy-peer-deps=true

--- a/tests/integration/test_jest_suite_cjs_vm/common.test.cjs
+++ b/tests/integration/test_jest_suite_cjs_vm/common.test.cjs
@@ -1,0 +1,40 @@
+const { PDFParse } = require('pdf-parse');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const __pdf = path.join(__dirname, '../../../reports/pdf/');
+
+test('jest framework test - dummy-test.pdf', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'dummy.pdf'));
+	const parser = new PDFParse({ data });
+	const result = await parser.getText();
+	await parser.destroy();
+	expect(result.text).toContain('Dummy PDF file');
+});
+
+test('jest framework test - image-test.pdf - ss', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'image-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getScreenshot();
+	await parser.destroy();
+	expect(result.pages[0].dataUrl.length).toBeGreaterThan(0);
+});
+
+test('jest framework test - image-test.pdf - embed', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'image-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getImage();
+	await parser.destroy();
+	expect(result.pages[0].images[0].dataUrl.length).toBeGreaterThan(0);
+});
+
+test('jest framework test - full-test.pdf', async () => {
+	const data = fs.readFileSync(path.join(__pdf, 'default-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getText({ last: 1 });
+	await parser.destroy();
+	expect(result.text).toContain('be interpreted as necessarily');
+});

--- a/tests/integration/test_jest_suite_cjs_vm/jest.config.cjs
+++ b/tests/integration/test_jest_suite_cjs_vm/jest.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.cjs'],
+  moduleFileExtensions: ['js', 'cjs', 'mjs'],
+  transform: {},
+  transformIgnorePatterns: [],
+  testEnvironmentOptions: {
+    customExportConditions: ['node', 'node-addons'],
+  },
+};

--- a/tests/integration/test_jest_suite_cjs_vm/package.json
+++ b/tests/integration/test_jest_suite_cjs_vm/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "test_jest_suite_cjs_vm",
+	"version": "1.0.0",
+	"description": "",
+	"license": "ISC",
+	"author": "",
+	"type": "commonjs",
+	"main": "common.test.cjs",
+	"private": "true",
+	"scripts": {
+		"build": "",
+		"test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest --verbose --no-cache --runInBand"
+	},
+	"dependencies": {
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
+	},
+	"devDependencies": {
+		"cross-env": "^10.1.0",
+		"jest": "latest"
+	}
+}

--- a/tests/integration/test_jest_suite_esm/.npmrc
+++ b/tests/integration/test_jest_suite_esm/.npmrc
@@ -1,0 +1,7 @@
+package-lock=false
+audit=false
+fund=false
+loglevel=error
+prefer-offline=true
+save=true
+legacy-peer-deps=true

--- a/tests/integration/test_jest_suite_esm/common.test.js
+++ b/tests/integration/test_jest_suite_esm/common.test.js
@@ -1,0 +1,44 @@
+import { PDFParse } from 'pdf-parse';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const __pdf = join(__dirname, '../../../reports/pdf/');
+
+test('jest framework test - dummy-test.pdf', async () => {
+	const data = readFileSync(join(__pdf, 'dummy.pdf'));
+	const parser = new PDFParse({ data });
+	const result = await parser.getText();
+	await parser.destroy();
+	expect(result.text).toContain('Dummy PDF file');
+});
+
+test('jest framework test - image-test.pdf - ss', async () => {
+	const data = readFileSync(join(__pdf, 'image-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getScreenshot();
+	await parser.destroy();
+	expect(result.pages[0].dataUrl.length).toBeGreaterThan(0);
+});
+
+test('jest framework test - image-test.pdf - embed', async () => {
+	const data = readFileSync(join(__pdf, 'image-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getImage();
+	await parser.destroy();
+	expect(result.pages[0].images[0].dataUrl.length).toBeGreaterThan(0);
+});
+
+test('jest framework test - full-test.pdf', async () => {
+	const data = readFileSync(join(__pdf, 'default-test.pdf'));
+
+	const parser = new PDFParse({ data });
+	const result = await parser.getText({ last: 1 });
+	await parser.destroy();
+	expect(result.text).toContain('be interpreted as necessarily');
+});

--- a/tests/integration/test_jest_suite_esm/jest.config.js
+++ b/tests/integration/test_jest_suite_esm/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.js'],
+  transform: {},
+};

--- a/tests/integration/test_jest_suite_esm/package.json
+++ b/tests/integration/test_jest_suite_esm/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "test_jest_suite_esm",
+	"version": "1.0.0",
+	"description": "",
+	"license": "ISC",
+	"author": "",
+	"type": "module",
+	"private": "true",
+	"scripts": {
+		"build": "",
+		"test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest --verbose --no-cache --runInBand"
+	},
+	"dependencies": {
+		"pdf-parse": "file:../../../reports/pdf-parse.tgz"
+	},
+	"devDependencies": {
+		"cross-env": "^10.1.0",
+		"jest": "latest"
+	}
+}


### PR DESCRIPTION
This pull request introduces three new integration test suites for the `pdf-parse` package, covering CommonJS, ESM, and Jest Light Runner environments. Each suite includes configuration files, test scripts, and sample tests to ensure compatibility and functionality of `pdf-parse` across different Node.js module systems and Jest runners.

**New Integration Test Suites**

*CommonJS VM Suite:*
- Added a new test suite in `test_jest_suite_cjs_vm` with Jest configuration, package setup, and `.npmrc` for dependency management. Includes tests for parsing PDF text and images using `pdf-parse`. [[1]](diffhunk://#diff-43f459fb253a82ac09e5ba9f48b1fbb354364587931252abaa9a50e424eec95fR1-R10) [[2]](diffhunk://#diff-d4bbc9b88b017ead84154a872538a8232cd66496256914545890f20a001b5cb9R1-R21) [[3]](diffhunk://#diff-bafe1923007ce5b0aaa989579d18912499f1d3d940c607eb71f2ff0386f7af7dR1-R7) [[4]](diffhunk://#diff-c507c9ac4bf37885c853bac1cb2e2065b783d6febb59d4244675d7f37aeb83e5R1-R40)

*ESM Suite:*
- Introduced an ESM-based test suite in `test_jest_suite_esm` with appropriate Jest configuration, package setup, and `.npmrc`. Tests verify `pdf-parse` functionality in an ES module context. [[1]](diffhunk://#diff-97cfed62b181dda8d561266d073a283c0723d8f7c82dd278745eea63e1ac3012R1-R5) [[2]](diffhunk://#diff-35f2faa77ca9f611f7af5e9f8ff72cb99dedde8e3e5736b79ce7fcddcb045473R1-R20) [[3]](diffhunk://#diff-bafe1923007ce5b0aaa989579d18912499f1d3d940c607eb71f2ff0386f7af7dR1-R7) [[4]](diffhunk://#diff-6957a2c4bde6cbe56fbfef24b20073e827a56b1718473a45a70cdac2cede2f8bR1-R44)

*Jest Light Runner Suite:*
- Added a test suite in `test_jest_light_runner` to test `pdf-parse` using the `jest-light-runner`, including configuration, package setup, and `.npmrc`. Also contains a Node.js environment check test. [[1]](diffhunk://#diff-068c2f91ee104cb12448dea0e8330064b3ed47c6cb43b40ab0554a348aa45752R1-R5) [[2]](diffhunk://#diff-b4384e63cd1539cd2e98f8b30260ccf402103df076e76e06056c4b7b902f231eR1-R23) [[3]](diffhunk://#diff-b47fde3746bf920052d2a08f4d4ce4d2d3f1f0a7fe7524e3574e3f494cf785beR1-R6) [[4]](diffhunk://#diff-2043663bf7aee45e0ad1aa685a5c5a754d1d7c2f8368d3fb70a540490e887f19R1-R42) [[5]](diffhunk://#diff-81e6a2475343c78e79d681fa22b7af1a0b828bf438b269492533928fb3fe09beR1-R8) [[6]](diffhunk://#diff-0fd0eeff1040243a76a496e9435016330a7d3ab24f6f5c773c6fb4f3f1ee4fe4R1-R38)

**Test Coverage Enhancements**

- All suites include tests for extracting text, screenshots, and embedded images from sample PDFs, as well as verifying expected content in the parsed results. [[1]](diffhunk://#diff-c507c9ac4bf37885c853bac1cb2e2065b783d6febb59d4244675d7f37aeb83e5R1-R40) [[2]](diffhunk://#diff-6957a2c4bde6cbe56fbfef24b20073e827a56b1718473a45a70cdac2cede2f8bR1-R44) [[3]](diffhunk://#diff-2043663bf7aee45e0ad1aa685a5c5a754d1d7c2f8368d3fb70a540490e887f19R1-R42)

**Configuration and Dependency Management**

- Added `.npmrc` files to ensure consistent, reproducible installs and to handle peer dependencies and logging preferences in all new test suites. [[1]](diffhunk://#diff-bafe1923007ce5b0aaa989579d18912499f1d3d940c607eb71f2ff0386f7af7dR1-R7) [[2]](diffhunk://#diff-b47fde3746bf920052d2a08f4d4ce4d2d3f1f0a7fe7524e3574e3f494cf785beR1-R6)

These changes improve the robustness of `pdf-parse` by validating its compatibility and behavior across multiple Node.js and Jest environments.