### PR TITLE
Update @napi-rs/canvas and pdfjs-dist dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,8 +128,8 @@
 		"pack": "npm update --save && npm outdated && npm pack --dry-run"
 	},
 	"dependencies": {
-		"@napi-rs/canvas": "0.1.82",
-		"pdfjs-dist": "5.4.394"
+		"@napi-rs/canvas": "0.1.84",
+		"pdfjs-dist": "5.4.449"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.7",


### PR DESCRIPTION
Bump @napi-rs/canvas from 0.1.82 to 0.1.84 and pdfjs-dist from 5.4.394 to 5.4.449 in package.json to include latest fixes and improvements.