### PR TITLE
bench: add pdf-oxide (native + WASM) to the text-extraction benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
 
 		"coverage": "vitest run --coverage",
 		"bench": "npm run bench:install && vitest bench --run",
-		"bench:install": "npm install --no-save pdf2json@latest",
+		"bench:install": "npm install --no-save pdf2json@latest pdf-oxide@latest pdf-oxide-wasm@latest",
 		"report": "npm run report:build && vite preview --outDir reports",
 		"report:build": "npm run build && npm run coverage && npm run bench && npm run typedoc:build",
 		"typedoc:build": "typedoc --options configs/typedoc.mjs --out reports/typedoc",

--- a/tests/benchmark/package.bench.ts
+++ b/tests/benchmark/package.bench.ts
@@ -2,6 +2,9 @@ import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import PDF2JSON from 'pdf2json';
+// pdf-oxide (Rust core): native Node addon + WASM build
+import { PdfDocument as OxideDocument } from 'pdf-oxide';
+import { WasmPdfDocument } from 'pdf-oxide-wasm';
 import { bench, describe } from 'vitest';
 
 import { PDFParse as PDFParseCJS } from '../../dist/pdf-parse.cjs';
@@ -47,6 +50,17 @@ async function pdf2json_promise(buffer: Buffer<ArrayBufferLike>) {
 	});
 }
 
+async function pdf_oxide_native_promise(buffer: Uint8Array) {
+	const doc = OxideDocument.openFromBuffer(buffer);
+	doc.extractAllText();
+}
+
+async function pdf_oxide_wasm_promise(buffer: Uint8Array) {
+	const doc = new WasmPdfDocument(buffer);
+	doc.extractAllText();
+	doc.free();
+}
+
 describe('Parsing Files', async () => {
 	const data = await readFile(__pdf);
 	const buffer = new Uint8Array(data);
@@ -78,6 +92,22 @@ describe('Parsing Files', async () => {
 		'pdf2json',
 		async () => {
 			await pdf2json_promise(Buffer.from(buffer));
+		},
+		{ iterations: 10 },
+	);
+
+	bench(
+		'pdf-oxide native',
+		async () => {
+			await pdf_oxide_native_promise(new Uint8Array(buffer));
+		},
+		{ iterations: 10 },
+	);
+
+	bench(
+		'pdf-oxide wasm',
+		async () => {
+			await pdf_oxide_wasm_promise(new Uint8Array(buffer));
 		},
 		{ iterations: 10 },
 	);


### PR DESCRIPTION
## What

Adds **pdf-oxide** (a Rust-core PDF library) to the package benchmark in `tests/benchmark/package.bench.ts`, alongside `pdf-parse` and `pdf2json`, on the same `solar-energy.pdf`:

- `pdf-oxide` — native Node addon (`PdfDocument.openFromBuffer(buf).extractAllText()`)
- `pdf-oxide-wasm` — WASM build (`new WasmPdfDocument(bytes).extractAllText()`)

`bench:install` now also installs the two packages `--no-save` (same pattern as `pdf2json`).

## Why

More backends make the benchmark more useful. For transparency, a local run on this exact `solar-energy.pdf` (10 iters + 3 warmup, text extraction) gave:

| Library | mean |
|---|---|
| pdf-oxide (native) | ~60ms |
| pdf-parse | ~75ms |
| pdf-oxide-wasm | ~86ms |
| pdf2json | ~266ms |

So pdf-parse comfortably beats the portable WASM build and is competitive with the native addon — happy to keep or drop any entry as you prefer. No production code touched; benchmark-only.